### PR TITLE
Replaced all includes with forward declarations

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -1,11 +1,11 @@
 #ifndef AST_H
 # define AST_H
 
-# include "str.h"
-# include "mem.h"
 # include <stdio.h>
 # include <stdlib.h>
-# include <stdbool.h> //header inutile ??
+# include <stdbool.h>
+
+typedef struct s_list t_list;
 
 typedef struct	s_strlist
 {
@@ -16,7 +16,7 @@ typedef struct	s_strlist
 typedef struct	s_dir
 {
 	int		nb_dir;
-	t_strlist	*head;
+	t_list	*head;
 }	t_dir;
 
 typedef enum e_leaf_type

--- a/include/env.h
+++ b/include/env.h
@@ -1,9 +1,6 @@
 #ifndef ENV_H
 # define ENV_H
 
-# include "mem.h"
-# include "str.h"
-# include "num.h"
 # include <unistd.h>
 
 void	env_set(void *e);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -1,28 +1,26 @@
 #ifndef MINISHELL_H
 # define MINISHELL_H
 
-# include "mem.h"
-# include "str.h"
-# include "env.h"
-# include "char.h"
-# include "list.h"
-# include <stdio.h>
+# include <readline/readline.h>
+# include <readline/history.h>
+# include <sys/stat.h>
 # include <unistd.h>
 # include <limits.h>
 # include <dirent.h>
-# include <sys/stat.h>
-# include <readline/readline.h>
-# include <readline/history.h>
+# include <stdio.h>
+# include "ast.h"
+# include "char.h"
+# include "env.h"
+# include "int.h"
+# include "list.h"
+# include "mem.h"
+# include "num.h"
+# include "sort.h"
+# include "str.h"
 
 # ifdef INCLUDE_TEST_HEADER
 #  include "test.h"
 # endif
-
-typedef struct	s_dir
-{
-	int		nb_dir;
-	t_list	*head;
-}	t_dir;
 
 typedef struct s_var
 {

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -1,13 +1,13 @@
 #ifndef MINISHELL_H
 # define MINISHELL_H
 
+# include <stdio.h>
 # include <readline/readline.h>
 # include <readline/history.h>
 # include <sys/stat.h>
 # include <unistd.h>
 # include <limits.h>
 # include <dirent.h>
-# include <stdio.h>
 # include "ast.h"
 # include "char.h"
 # include "env.h"

--- a/include/num.h
+++ b/include/num.h
@@ -1,8 +1,6 @@
 #ifndef NUMBER_H
 # define NUMBER_H
 
-# include "mem.h"
-
 char	*num_itoa(int nb);
 
 #endif

--- a/include/sort.h
+++ b/include/sort.h
@@ -1,7 +1,7 @@
 #ifndef SORT_H
 # define SORT_H
 
-#include "list.h"
+typedef struct s_list t_list;
 
 t_list	*ft_qsort(t_list *list, int (*f)(void *, void *));
 int		ascii_sort(void *a, void *b);

--- a/include/str.h
+++ b/include/str.h
@@ -4,7 +4,8 @@
 # include <stdbool.h>
 # include <stdlib.h>
 # include <stdarg.h>
-# include "mem.h"
+
+typedef enum e_lifetime t_lifetime;
 
 typedef struct	s_replace
 {

--- a/src/parsing/ast/ast.c
+++ b/src/parsing/ast/ast.c
@@ -1,4 +1,6 @@
 #include "ast.h"
+#include "str.h"
+#include "mem.h"
 
 t_ast_data	*init_ast_data(char *input)
 {

--- a/src/parsing/ast/leaf.c
+++ b/src/parsing/ast/leaf.c
@@ -1,4 +1,5 @@
 #include "ast.h"
+#include "mem.h"
 
 static inline bool _is_filename(t_ast *node)
 {

--- a/src/parsing/ast/ope.c
+++ b/src/parsing/ast/ope.c
@@ -1,4 +1,6 @@
 #include "ast.h"
+#include "str.h"
+#include "mem.h"
 
 static t_ope_type	_string_to_ope_type(char *word)
 {

--- a/src/tools/env/env.c
+++ b/src/tools/env/env.c
@@ -1,4 +1,7 @@
 #include "env.h"
+#include "str.h"
+#include "num.h"
+#include "mem.h"
 
 static void	**_env(void)
 {

--- a/src/tools/number/num_itoa.c
+++ b/src/tools/number/num_itoa.c
@@ -1,4 +1,5 @@
 #include "num.h"
+#include "mem.h"
 
 static int	_count_digit(long n)
 {

--- a/src/tools/string/str_replace.c
+++ b/src/tools/string/str_replace.c
@@ -1,4 +1,5 @@
 #include "str.h"
+#include "mem.h"
 
 void	str_replace(t_lifetime lft, t_replace data)
 {

--- a/src/tools/string/str_vjoin.c
+++ b/src/tools/string/str_vjoin.c
@@ -1,4 +1,5 @@
 #include "str.h"
+#include "mem.h"
 
 static size_t	_get_length(size_t nb_args, va_list lst)
 {


### PR DESCRIPTION
This is to avoid any circular includes issues. Now we can use minishell.h anywhere in the project and the c file will compile. 