### PR TITLE
fix(prompt): added escape caracters to ainsi color codes

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -44,7 +44,7 @@ bool	handle_escape(char *input, size_t *len, char c);
 void	expand(t_alloc *alloc, char **word, char **input);
 void	expand_tilde(t_alloc *alloc, char **word);
 void	expand_wildcard(t_alloc *alloc, char **input, char **word);
-char	*readline_prompt(char *buf, size_t size);
+char	*readline_prompt(t_alloc *alloc);
 void	input_loop(t_alloc *alloc_prog);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -13,14 +13,13 @@ void	increase_shlvl(t_alloc *alloc)
 
 void	input_loop(t_alloc *alloc_prog)
 {
-	char	prompt[PATH_MAX + 20];
 	char	*input;
 	t_alloc	*alloc_cmd;
 
 	while (1)
 	{
 		alloc_cmd = new_arena_allocator(ARENA_BLOCK_SIZE);
-		input = readline(readline_prompt(prompt, PATH_MAX + 20));
+		input = readline(readline_prompt(alloc_cmd));
 		if (g_signal == SIGINT)
 		{
 			free_allocator(&alloc_cmd);

--- a/src/prompt/readline_prompt.c
+++ b/src/prompt/readline_prompt.c
@@ -25,31 +25,15 @@ static char	*_get_git_head(void)
 	return (NULL);
 }
 
-char	*readline_prompt(char *buf, size_t size)
+char	*readline_prompt(t_alloc *alloc)
 {
 	char	cwd[PATH_MAX];
-	int		n;
 	char	*git_head;
 
 	if (getcwd(cwd, sizeof(cwd)) == NULL)
 		cwd[0] = '\0';
 	git_head = _get_git_head();
 	if (git_head)
-	{
-		n = snprintf(buf, size,
-			"\001\033[1;32m\002minishell \001\033[1;35m\002%s "
-			"\001\033[1;32m\002git:(\001\033[1;33m\002%s\001\033[1;32m\002"
-			") \001\033[1;32m\002#\001\033[0m\002 ",
-			cwd, git_head);
-	}
-	else
-	{
-		n = snprintf(buf, size,
-			"\001\033[1;32m\002minishell \001\033[1;35m\002%s "
-			"\001\033[1;32m\002#\001\033[0m\002 ",
-			cwd);
-	}
-	if (n < 0 || (size_t)n >= size)
-		return (NULL);
-	return (buf);
+		return (str_vjoin(alloc, 5, "\001\033[1;32m\002minishell \001\033[1;35m\002", cwd, "\001\033[1;32m\002 git:(\001\033[1;33m\002", git_head, "\001\033[1;32m\002)\001\033[1;32m\002#\001\033[0m\002 "));
+	return (str_vjoin(alloc, 3, "\001\033[1;32m\002minishell \001\033[1;35m\002", cwd, "\001\033[1;32m\002\001\033[1;32m\002#\001\033[0m\002 "));
 }

--- a/src/prompt/readline_prompt.c
+++ b/src/prompt/readline_prompt.c
@@ -37,13 +37,16 @@ char	*readline_prompt(char *buf, size_t size)
 	if (git_head)
 	{
 		n = snprintf(buf, size,
-			"\033[1;32mminishell\033[0m \033[1;35m%s\033[0m \033[1;32mgit:(\033[1;33m%s\033[1;32m) #\033[0m ",
+			"\001\033[1;32m\002minishell \001\033[1;35m\002%s "
+			"\001\033[1;32m\002git:(\001\033[1;33m\002%s\001\033[1;32m\002"
+			") \001\033[1;32m\002#\001\033[0m\002 ",
 			cwd, git_head);
 	}
 	else
 	{
 		n = snprintf(buf, size,
-			"\033[1;32mminishell\033[0m \033[1;35m%s\033[0m \033[1;32m# \033[0m",
+			"\001\033[1;32m\002minishell \001\033[1;35m\002%s "
+			"\001\033[1;32m\002#\001\033[0m\002 ",
 			cwd);
 	}
 	if (n < 0 || (size_t)n >= size)


### PR DESCRIPTION
The issue was that the terminal can’t distinguish between characters that occupy space on the screen and those that don’t. Every ANSI color code must be wrapped with \001 and \002 to let readline know that these are non-printable sequences and shouldn’t be counted toward the prompt’s visible length.